### PR TITLE
Fix debug attribute name

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -67,6 +67,6 @@ template '/etc/ipsec.conf' do
   owner 'root'
   group 'root'
   mode '0644'
-  variables('debug' => node['strongswanaws']['debug'])
+  variables('debug' => node['awsstrongswan']['debug'])
   notifies :restart, 'service[strongswan]', :delayed
 end


### PR DESCRIPTION
Hi there, thanks for writing this cookbook! It allowed me to create a cross-region VPC peering solution without much trouble. I just had to change the attribute name used in this line of code to match what is set in the attributes file. I know it doesn't match the name of the cookbook, but there were two attributes in the file so I therefore made the choice to name it as you can see. It's working great for me. I hope this helps. Please let me know if you'll like me to adjust this PR.

Cheers,

Ian D. Rossi