### PR TITLE
Adds option to use encrypted data bag

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,13 @@ This cookbook does not depend on any other cookbooks.
 This cookbook uses the following attributes.
 
 ```
-.-------------------------------------------------------------------------------------------.
-| Key                          | Type    | Description                           | Default  |
-|-------------------------------------------------------------------------------------------|
-| ['awsstrongswan']['debug']   | Boolean | Cause charon to log debug information | true     |
-| ['awsstrongswan']['tunnels'] | Array   | Tunnels to which to connect           | empty [] |
-'-------------------------------------------------------------------------------------------'
+.-------------------------------------------------------------------------------------------------------.
+| Key                                      | Type    | Description                           | Default  |
+|-------------------------------------------------------------------------------------------------------|
+| ['awsstrongswan']['debug']               | Boolean | Cause charon to log debug information | true     |
+| ['awsstrongswan']['databag_encrypted']   | Boolean | Cause charon to log debug information | false    |
+| ['awsstrongswan']['tunnels']             | Array   | Tunnels to which to connect           | empty [] |
+'-------------------------------------------------------------------------------------------------------'
 ```
 
 These attributes can be set as below.
@@ -57,6 +58,16 @@ These attributes can be set as below.
 "default_attributes": {
   "strongswanaws": {
     "debug": true
+  }
+}
+```
+
+`['awsstrongswan']['databag_encrypted']`:
+
+```json
+"default_attributes": {
+  "strongswanaws": {
+    "databag_encrypted": true
   }
 }
 ```
@@ -102,6 +113,8 @@ The item `tunnel_keys` should look as shown below.
 ```
 
 There may be zero or more tunnels in the `tunnel_keys` list.
+
+If you choose to encrypt your data bag, set the `['awsstrongswan']['databag_encrypted']` to true.
 
 ## Recipes
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,6 +2,7 @@
 
 # Makes StrongSwan logs debug notices
 default['awsstrongswan']['debug'] = false
+default['awsstrongswan']['databag_encrypted'] = false
 
 # A list of IPSec tunnel configuration info
 # Example:

--- a/recipes/tunnels.rb
+++ b/recipes/tunnels.rb
@@ -4,7 +4,11 @@
 
 # There are a list of pre-shared keys indexed
 # by chef environment in the vpn_keys data bag.
-tunnel_keys = data_bag_item('strongswanaws', 'tunnel_keys')
+if node['awsstrongswan']['databag_encrypted']
+  tunnel_keys = data_bag_item('strongswanaws', 'tunnel_keys')
+else
+  tunnel_keys = Chef::EncryptedDataBagItem.load('strongswanaws', 'tunnel_keys').to_hash
+end
 key_configs = tunnel_keys['key_configs']
 
 


### PR DESCRIPTION
We'd like to store the PSKs as encrypted data bags.

### Testing

Verified convergence and secrets file gets created with attribute set to true.

Verified pre-existing functionality isn't broken when cooking with normal data bags.